### PR TITLE
Add basic Jest and Pytest setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+      - name: Install Node dependencies
+        run: |
+          cd app
+          npm ci
+      - name: Lint
+        run: |
+          cd app
+          npm run lint
+      - name: Node tests
+        run: |
+          cd app
+          npm test
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Run Pytest
+        run: PYTHONPATH=ble pytest

--- a/README.md
+++ b/README.md
@@ -268,6 +268,21 @@ The creation of the .deb package is done in a Docker container. To do this, foll
 2. Once the container is started, execute the `build.sh` script.
 3. To send the .deb file to the GitHub repository, use the `deb-push.sh` bash script (outside the container) available at the root of the project. This script clones a repository and sends everything to the `gh-pages` branch of the repository.
 
+## Tests
+
+Node tests are located in `app/tests` and can be executed with:
+
+```bash
+cd app
+npm test
+```
+
+Python tests reside in `ble/tests` and can be run using Pytest:
+
+```bash
+PYTHONPATH=ble pytest
+```
+
 ## License
 
 This project is licensed under the GPL v3 License - see the LICENSE file for details.

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
+};

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,9 @@
     "copy-certs": "cp -r ./src/certs/ ./dist/certs/",
     "eslint": "npx eslint .",
     "start": "node ./dist/main.js",
-    "dev": "npx tsx src/main.ts"
+    "dev": "npx tsx src/main.ts",
+    "lint": "npm run eslint",
+    "test": "jest"
   },
   "dependencies": {
     "@sentry/node": "^8.47.0",
@@ -43,6 +45,8 @@
     "nodemon": "^3.1.9",
     "tsc-alias": "^1.8.10",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/app/tests/validators.test.ts
+++ b/app/tests/validators.test.ts
@@ -1,0 +1,11 @@
+import { isValidIP } from '../src/utils/validators';
+
+describe('isValidIP', () => {
+  test('valid IPv4 returns true', () => {
+    expect(isValidIP('192.168.0.1')).toBe(true);
+  });
+
+  test('invalid IP returns false', () => {
+    expect(isValidIP('999.999.999.999')).toBe(false);
+  });
+});

--- a/ble/tests/test_validators.py
+++ b/ble/tests/test_validators.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.validators import is_valid_ip
+
+
+def test_is_valid_ip_valid_ipv4():
+    assert is_valid_ip('192.168.0.1')
+
+
+def test_is_valid_ip_invalid():
+    assert not is_valid_ip('999.999.999.999')


### PR DESCRIPTION
## Summary
- add `lint` and `test` commands in `app/package.json`
- configure Jest for TypeScript
- provide sample Node and Python tests
- add CI workflow running lint and tests
- document how to run tests in the README

## Testing
- `npm run lint` *(fails: cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: jest not found)*
- `PYTHONPATH=ble pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f521fb0c88324bb110057541b3425